### PR TITLE
addresses issue where query parameters might be supplied incorrectly

### DIFF
--- a/local-server.js
+++ b/local-server.js
@@ -1,14 +1,15 @@
-var http   = require("http"),
-	url    = require("url"),
-	path   = require("path"),
-	fs     = require("fs"),
-	tachyon= require( './index' ),
-	args = process.argv.slice(2),
-	port   = Number( args[0] ) ? args[0] : 8080,
-	debug  = args.indexOf( '--debug' ) > -1
+var http = require("http"),
+    url = require("url"),
+    path = require("path"),
+    fs = require("fs"),
+    tachyon = require('./index'),
+    param_util = require('./param_util'),
+    args = process.argv.slice(2),
+    port = Number(args[0]) ? args[0] : 8080,
+    debug = args.indexOf('--debug') > -1
 
 http.createServer( function( request, response ) {
-	var params = url.parse( request.url, true )
+	var params = url.parse( param_util.decodeQuery(request.url), true)
 
 	if ( debug ) {
 		console.log( Date(), request.url )

--- a/param_util.js
+++ b/param_util.js
@@ -1,0 +1,20 @@
+const escaped_one_to_xml_special_map = {
+    '&amp;': '&',
+    '&quot;': '"',
+    '&lt;': '<',
+    '&gt;': '>'
+};
+
+function decodeQuery(string) {
+    /*
+    * this is a function that can decode queries from URL fragments
+    * like "http://localhost:8080/uploads/2016/10/Space-Rocket-Emoji.png?resize=1440,960&amp;crop=0,0,100,67"
+    * this makes sure that the params in the query are parsed correctly
+    * */
+    return string.replace(/(&quot;|&lt;|&gt;|&amp;)/g,
+        function (str, item) {
+            return escaped_one_to_xml_special_map[item];
+        });
+}
+
+module.exports.decodeQuery = decodeQuery

--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
-var http   = require("http"),
-	url    = require("url"),
-	path   = require("path"),
-	fs     = require("fs"),
-	tachyon= require( './index' ),
-	args = process.argv.slice(2),
-	port   = Number( args[0] ) ? args[0] : 8080,
-	debug  = args.indexOf( '--debug' ) > -1
+var http = require("http"),
+    url = require("url"),
+    path = require("path"),
+    fs = require("fs"),
+    tachyon = require('./index'),
+    param_util = require('./param_util'),
+    args = process.argv.slice(2),
+    port = Number(args[0]) ? args[0] : 8080,
+    debug = args.indexOf('--debug') > -1
 
 var config = {}
 if ( process.env.AWS_REGION && process.env.AWS_S3_BUCKET ) {
@@ -19,7 +20,7 @@ if ( process.env.AWS_REGION && process.env.AWS_S3_BUCKET ) {
 }
 
 http.createServer( function( request, response ) {
-	var params = url.parse( request.url, true )
+	var params = url.parse(param_util.decodeQuery(request.url), true)
 
 	if ( debug ) {
 		console.log( Date(), request.url )


### PR DESCRIPTION
This hopefully helps node parse incoming urls properly. For example `http://localhost:8080/uploads/2016/10/Space-Rocket-Emoji.png?resize=1440,960&amp;crop=0,0,100,67` will produce the following params:
```
query:
  {
     resize: '1440,960',
     crop: '0,0,100,67',
  }
```